### PR TITLE
Fix Docker version check

### DIFF
--- a/scripts/launch
+++ b/scripts/launch
@@ -28,10 +28,20 @@ done
 BTRFS_VERSION="$(which btrfs)" || { echo 'Please install btrfs-tools. (apt-get install btrfs-tools)' ; exit 1; }
 DOCKER_VERSION="$(docker --version | awk '{ print $3 }')"
 
-if [ "$DOCKER_VERSION" != "1.5.0," ] ; then
-    echo "docker 1.5.0 required"
+REGEX="([0-9]+)\.([0-9]+)\.([0-9]+),"
+
+# pin major version at 1, in case pfs needs update
+if [ $(echo "$DOCKER_VERSION" | sed -E "s/$REGEX/\1/") -ne "1" ]
+then
+    echo "This version of pfs only supports Docker 1.x, you're running $DOCKER_VERSION"
+    echo "Please upgrade pfs for support"
+    exit 1
+# docker versions below 1.5 are not supported
+elif [ $(echo "$DOCKER_VERSION" | sed -E "s/$REGEX/\2/") -lt "5" ]
+then
+    echo "Docker >= 1.5.0 is required"
     echo "See: https://docs.docker.com/installation/ubuntulinux/#docker-maintained-package-installation"
-    exit 1;
+    exit 1
 fi
 
 btrfs --version | grep 3.14 || { echo 'Upgrade btrfs-tools to 3.14.' ; exit 1; }


### PR DESCRIPTION
This commit fixes the Docker version check by parsing it with sed.
It enforces:
  - major version = 1
  - minor version >= 5

When the Docker major is bumped (= backwards incompatible change), we
stay on the safe side and force users to upgrade for support.

This PR is a resubmit/redo of #53.

Fixes: #52
/cc @jdoliner @waitingkuo