### PR TITLE
Replace harcoded Docker host address with environment variable

### DIFF
--- a/lib/container/container.go
+++ b/lib/container/container.go
@@ -4,10 +4,13 @@ package container
 import (
 	"io"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/fsouza/go-dockerclient"
 )
+
+const defaultDockerHost = "unix:///var/run/docker.sock"
 
 var DefaultConfig = docker.Config{
 	AttachStdin:  true,
@@ -18,7 +21,7 @@ var DefaultConfig = docker.Config{
 }
 
 func RawStartContainer(opts docker.CreateContainerOptions) (string, error) {
-	client, err := docker.NewClient("unix:///var/run/docker.sock")
+	client, err := docker.NewClient(getDockerHost())
 	if err != nil {
 		log.Print(err)
 		return "", err
@@ -44,7 +47,7 @@ func StartContainer(image string, command []string) (string, error) {
 }
 
 func StopContainer(id string) error {
-	client, err := docker.NewClient("unix:///var/run/docker.sock")
+	client, err := docker.NewClient(getDockerHost())
 	if err != nil {
 		log.Print(err)
 		return err
@@ -53,7 +56,7 @@ func StopContainer(id string) error {
 }
 
 func KillContainer(id string) error {
-	client, err := docker.NewClient("unix:///var/run/docker.sock")
+	client, err := docker.NewClient(getDockerHost())
 	if err != nil {
 		log.Print(err)
 		return err
@@ -62,7 +65,7 @@ func KillContainer(id string) error {
 }
 
 func IpAddr(containerId string) (string, error) {
-	client, err := docker.NewClient("unix:///var/run/docker.sock")
+	client, err := docker.NewClient(getDockerHost())
 	if err != nil {
 		log.Print(err)
 		return "", err
@@ -78,7 +81,7 @@ func IpAddr(containerId string) (string, error) {
 
 func PullImage(image string) error {
 	repo_tag := strings.Split(image, ":")
-	client, err := docker.NewClient("unix:///var/run/docker.sock")
+	client, err := docker.NewClient(getDockerHost())
 	if err != nil {
 		log.Print(err)
 		return err
@@ -91,7 +94,7 @@ func PullImage(image string) error {
 }
 
 func PipeToStdin(id string, in io.Reader) error {
-	client, err := docker.NewClient("unix:///var/run/docker.sock")
+	client, err := docker.NewClient(getDockerHost())
 	if err != nil {
 		log.Print(err)
 		return err
@@ -105,7 +108,7 @@ func PipeToStdin(id string, in io.Reader) error {
 }
 
 func ContainerLogs(id string, out io.Writer) error {
-	client, err := docker.NewClient("unix:///var/run/docker.sock")
+	client, err := docker.NewClient(getDockerHost())
 	if err != nil {
 		log.Print(err)
 		return err
@@ -121,11 +124,21 @@ func ContainerLogs(id string, out io.Writer) error {
 }
 
 func WaitContainer(id string) (int, error) {
-	client, err := docker.NewClient("unix:///var/run/docker.sock")
+	client, err := docker.NewClient(getDockerHost())
 	if err != nil {
 		log.Print(err)
 		return 0, err
 	}
 
 	return client.WaitContainer(id)
+}
+
+func getDockerHost() (host string) {
+	host = os.Getenv("DOCKER_HOST")
+
+	if host == "" {
+		host = defaultDockerHost
+	}
+
+	return
 }


### PR DESCRIPTION
Just a try at issue #71 .

Get the value from the environment, if empty set the default. I thought a default value would be nice (good software comes with good defaults or not at all I guess).
