### PR TITLE
prefix error constants with Err, prefix error strings with "pfs: ", group package vars

### DIFF
--- a/lib/btrfs/btrfs.go
+++ b/lib/btrfs/btrfs.go
@@ -24,8 +24,12 @@ import (
 	"github.com/pachyderm/pfs/lib/shell"
 )
 
-var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-var once sync.Once
+var (
+	ErrComplete = errors.New("pfs: complete")
+
+	letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	once    sync.Once
+)
 
 // localVolume returns the path *inside* the container that we look for the
 // btrfs volume at
@@ -445,9 +449,9 @@ func createNewBranch(repo string) error {
 		if err != nil {
 			return err
 		}
-		return Complete
+		return ErrComplete
 	})
-	if err != nil && err != Complete {
+	if err != nil && err != ErrComplete {
 		return err
 	}
 	return nil
@@ -653,8 +657,6 @@ type CommitInfo struct {
 	gen, id, parent, Path string
 }
 
-var Complete = errors.New("Complete")
-
 // Commits is a wrapper around `Log` which parses the output in to a convenient
 // struct
 func Commits(repo, from string, order int, cont func(CommitInfo) error) error {
@@ -691,11 +693,11 @@ func GetFrom(repo string) (string, error) {
 		}
 		if isCommit {
 			from = c.Path
-			return Complete
+			return ErrComplete
 		}
 		return nil
 	})
-	if err != nil && err != Complete {
+	if err != nil && err != ErrComplete {
 		return "", err
 	}
 

--- a/lib/pipeline/pipeline_test.go
+++ b/lib/pipeline/pipeline_test.go
@@ -302,8 +302,8 @@ run sleep 100
 	r := NewRunner("pipeline", inRepo, outPrefix, "commit", "master", "0-1")
 	go func() {
 		err := r.Run()
-		if err != Cancelled {
-			t.Fatal("Should get `Cancelled` error.")
+		if err != ErrCancelled {
+			t.Fatal("Should get `ErrCancelled` error.")
 		}
 	}()
 

--- a/lib/route/route.go
+++ b/lib/route/route.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pachyderm/pfs/lib/etcache"
 )
 
-var NoHosts = errors.New("No hosts found")
+var ErrNoHosts = errors.New("pfs: no hosts found")
 
 func HashResource(resource string) uint64 {
 	return uint64(adler32.Checksum([]byte(resource)))
@@ -148,7 +148,7 @@ func Multicast(r *http.Request, etcdKey string) ([]*http.Response, error) {
 	}
 	endpoints := _endpoints.Node.Nodes
 	if len(endpoints) == 0 {
-		return nil, NoHosts
+		return nil, ErrNoHosts
 	}
 
 	// If the request has a body we need to store it in memory because it needs


### PR DESCRIPTION
three things:

- golang idiom is to prefix error constant variable names with `Err`
- there's parts of the code that compare an error with these constants. problem is, this function returns true:

```go
var ErrCancelled = errors.New("cancelled")
func foo() bool {
  return ErrCancelled == errors.New("cancelled")
}
```

so if you ever use some other package that also returns an error with the string "cancelled", bug waiting to happen. overall a weak point of golang for sure, but ya...prefix helps :)

- grouped package variables at the top of the file